### PR TITLE
Add dockware compose file and example Team plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # 8mEM
-emplyee management
+
+This repository contains a simple Shopware plugin example named **TeamPlugin**. It provides a skeleton to manage employees in the Shopware administration and exposes a CMS block/element for the storefront.
+
+## Usage
+
+1. Start the development environment using [dockware](https://dockware.io/):
+
+   ```bash
+   docker-compose up -d
+   ```
+
+   The compose file mounts persistent volumes so your data will survive container restarts.
+
+2. Connect via SSH to the container for development:
+
+   ```bash
+   ssh root@localhost -p 22
+   ```
+
+   The default password is `dockware`.
+
+3. Place the `TeamPlugin` folder inside the `custom/plugins/` directory of the Shopware installation and install it via the administration or CLI.
+
+4. Compile the administration assets:
+
+   ```bash
+   bin/console plugin:refresh
+   bin/console plugin:install --activate TeamPlugin
+   bin/console theme:compile
+   ```
+
+This will register a new menu entry under **Content** -> **Team** where employees can be managed.

--- a/TeamPlugin/composer.json
+++ b/TeamPlugin/composer.json
@@ -1,0 +1,20 @@
+{
+  "name": "custom/team-plugin",
+  "type": "shopware-platform-plugin",
+  "license": "MIT",
+  "require": {
+    "shopware/core": "*"
+  },
+  "extra": {
+    "shopware-plugin-class": "TeamPlugin\\TeamPlugin",
+    "label": {
+      "en-GB": "Team Plugin",
+      "de-DE": "Team Plugin"
+    }
+  },
+  "autoload": {
+    "psr-4": {
+      "TeamPlugin\\": "src/"
+    }
+  }
+}

--- a/TeamPlugin/src/Core/Content/Employee/EmployeeCollection.php
+++ b/TeamPlugin/src/Core/Content/Employee/EmployeeCollection.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace TeamPlugin\Core\Content\Employee;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @method void add(EmployeeEntity $entity)
+ * @method void set(string $key, EmployeeEntity $entity)
+ * @method EmployeeEntity[] getIterator()
+ * @method EmployeeEntity[] getElements()
+ * @method EmployeeEntity|null get(string $key)
+ * @method EmployeeEntity|null first()
+ * @method EmployeeEntity|null last()
+ */
+class EmployeeCollection extends EntityCollection
+{
+    protected function getExpectedClass(): string
+    {
+        return EmployeeEntity::class;
+    }
+}

--- a/TeamPlugin/src/Core/Content/Employee/EmployeeDefinition.php
+++ b/TeamPlugin/src/Core/Content/Employee/EmployeeDefinition.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace TeamPlugin\Core\Content\Employee;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BlobField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
+
+class EmployeeDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'team_employee';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function getCollectionClass(): string
+    {
+        return EmployeeCollection::class;
+    }
+
+    public function getEntityClass(): string
+    {
+        return EmployeeEntity::class;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new Required(), new PrimaryKey()),
+            new StringField('name', 'name'),
+            new StringField('position', 'position'),
+            new LongTextField('description', 'description'),
+            new BlobField('background_image', 'backgroundImage'),
+            new BlobField('person_image', 'personImage'),
+        ]);
+    }
+}

--- a/TeamPlugin/src/Core/Content/Employee/EmployeeEntity.php
+++ b/TeamPlugin/src/Core/Content/Employee/EmployeeEntity.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace TeamPlugin\Core\Content\Employee;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\System\Media\MediaEntity;
+
+class EmployeeEntity extends Entity
+{
+    protected string $name;
+    protected string $position;
+    protected string $description;
+    protected ?MediaEntity $backgroundImage = null;
+    protected ?MediaEntity $personImage = null;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getPosition(): string
+    {
+        return $this->position;
+    }
+
+    public function setPosition(string $position): void
+    {
+        $this->position = $position;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): void
+    {
+        $this->description = $description;
+    }
+
+    public function getBackgroundImage(): ?MediaEntity
+    {
+        return $this->backgroundImage;
+    }
+
+    public function setBackgroundImage(?MediaEntity $backgroundImage): void
+    {
+        $this->backgroundImage = $backgroundImage;
+    }
+
+    public function getPersonImage(): ?MediaEntity
+    {
+        return $this->personImage;
+    }
+
+    public function setPersonImage(?MediaEntity $personImage): void
+    {
+        $this->personImage = $personImage;
+    }
+}

--- a/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/component/team-cms-element.html.twig
+++ b/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/component/team-cms-element.html.twig
@@ -1,0 +1,3 @@
+<div class="team-element">
+    <p>Employee Element Placeholder</p>
+</div>

--- a/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/component/team-cms-element.js
+++ b/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/component/team-cms-element.js
@@ -1,0 +1,14 @@
+import template from './team-cms-element.html.twig';
+
+Shopware.Component.register('team-cms-element', {
+    template,
+    mixins: [
+        'cms-element'
+    ],
+    props: {
+        element: {
+            type: Object,
+            required: true
+        }
+    }
+});

--- a/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/index.js
+++ b/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/index.js
@@ -1,0 +1,10 @@
+import './component/team-cms-element';
+import './preview/team-cms-element-preview';
+
+Shopware.Service('cmsService').registerCmsBlock({
+    name: 'team-block',
+    label: 'Team Block',
+    category: 'text-image',
+    component: 'team-cms-element',
+    previewComponent: 'team-cms-element-preview'
+});

--- a/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/preview/team-cms-element-preview.html.twig
+++ b/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/preview/team-cms-element-preview.html.twig
@@ -1,0 +1,3 @@
+<div class="team-element-preview">
+    <p>Employee Preview Placeholder</p>
+</div>

--- a/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/preview/team-cms-element-preview.js
+++ b/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/preview/team-cms-element-preview.js
@@ -1,0 +1,5 @@
+import template from './team-cms-element-preview.html.twig';
+
+Shopware.Component.register('team-cms-element-preview', {
+    template
+});

--- a/TeamPlugin/src/Resources/app/administration/src/main.js
+++ b/TeamPlugin/src/Resources/app/administration/src/main.js
@@ -1,0 +1,2 @@
+import './module/team-plugin';
+import './extension/sw-cms';

--- a/TeamPlugin/src/Resources/app/administration/src/module/team-plugin/index.js
+++ b/TeamPlugin/src/Resources/app/administration/src/module/team-plugin/index.js
@@ -1,0 +1,25 @@
+import './page/team-list';
+
+Shopware.Module.register('team-plugin', {
+    type: 'plugin',
+    name: 'TeamPlugin',
+    title: 'Team',
+    description: 'Manage employees',
+    color: '#9AA8B5',
+    icon: 'default-avatar-single',
+    routes: {
+        list: {
+            component: 'team-list',
+            path: 'list'
+        }
+    },
+    navigation: [
+        {
+            label: 'Team',
+            color: '#9AA8B5',
+            path: 'team.plugin.list',
+            icon: 'default-avatar-single',
+            parent: 'sw-content'
+        }
+    ]
+});

--- a/TeamPlugin/src/Resources/app/administration/src/module/team-plugin/page/team-list/index.js
+++ b/TeamPlugin/src/Resources/app/administration/src/module/team-plugin/page/team-list/index.js
@@ -1,0 +1,8 @@
+import template from './team-list.html.twig';
+
+Shopware.Component.register('team-list', {
+    template,
+    data() {
+        return {};
+    }
+});

--- a/TeamPlugin/src/Resources/app/administration/src/module/team-plugin/page/team-list/team-list.html.twig
+++ b/TeamPlugin/src/Resources/app/administration/src/module/team-plugin/page/team-list/team-list.html.twig
@@ -1,0 +1,4 @@
+<div class="sw-container">
+    <h1>Employee List</h1>
+    <!-- Placeholder for employee grid -->
+</div>

--- a/TeamPlugin/src/Resources/config/plugin.xml
+++ b/TeamPlugin/src/Resources/config/plugin.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<plugin xmlns="http://www.shopware.com/schemas/plugin/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <label lang="en-GB">Team Plugin</label>
+    <label lang="de-DE">Team Plugin</label>
+
+    <admin>
+        <javascript>Resources/app/administration/src/main.js</javascript>
+    </admin>
+</plugin>

--- a/TeamPlugin/src/Resources/config/services.xml
+++ b/TeamPlugin/src/Resources/config/services.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="TeamPlugin\Core\Content\Employee\EmployeeDefinition" />
+    </services>
+</container>

--- a/TeamPlugin/src/TeamPlugin.php
+++ b/TeamPlugin/src/TeamPlugin.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace TeamPlugin;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+use Shopware\Core\Framework\Plugin\Context\UninstallContext;
+
+class TeamPlugin extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+        // custom install logic
+    }
+
+    public function uninstall(UninstallContext $uninstallContext): void
+    {
+        parent::uninstall($uninstallContext);
+        // custom uninstall logic
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.8"
+services:
+  shop:
+    image: dockware/dev:latest
+    ports:
+      - "80:80"
+      - "3306:3306"
+      - "22:22"
+    environment:
+      - APP_ENV=dev
+    volumes:
+      - shopware_db:/var/lib/mysql
+      - shopware_files:/var/www/html
+volumes:
+  shopware_db:
+  shopware_files:


### PR DESCRIPTION
## Summary
- add example dockware `docker-compose.yml`
- add `TeamPlugin` skeleton with DAL entity and admin module
- document how to run the environment and plugin

## Testing
- `composer validate` *(fails: command not found)*
- `php -l` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a6a10f4c8832aa5421e4b6e985af5