### PR TITLE
Implement team management basics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 8mEM
 
-This repository contains a simple Shopware plugin example named **TeamPlugin**. It provides a skeleton to manage employees in the Shopware administration and exposes a CMS block/element for the storefront.
+This repository contains a simple Shopware plugin example named **TeamPlugin**. It provides a skeleton to manage employees in the Shopware administration and exposes a CMS block/element for the storefront. The plugin includes a basic employee list module and a CMS element that lets you select multiple employees for a page.
 
 ## Usage
 

--- a/TeamPlugin/src/Migration/Migration1682235151EmployeeTable.php
+++ b/TeamPlugin/src/Migration/Migration1682235151EmployeeTable.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace TeamPlugin\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1682235151EmployeeTable extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1682235151;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement(
+            'CREATE TABLE IF NOT EXISTS `team_employee` (
+                `id` BINARY(16) NOT NULL,
+                `name` VARCHAR(255) NOT NULL,
+                `position` VARCHAR(255) NOT NULL,
+                `description` LONGTEXT NULL,
+                `background_image` LONGBLOB NULL,
+                `person_image` LONGBLOB NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;'
+        );
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}

--- a/TeamPlugin/src/Resources/app/administration/snippet/de-DE.json
+++ b/TeamPlugin/src/Resources/app/administration/snippet/de-DE.json
@@ -1,0 +1,6 @@
+{
+  "team-plugin": {
+    "employeeList": "Mitarbeiterliste",
+    "employeePreview": "Team Vorschau"
+  }
+}

--- a/TeamPlugin/src/Resources/app/administration/snippet/en-GB.json
+++ b/TeamPlugin/src/Resources/app/administration/snippet/en-GB.json
@@ -1,0 +1,6 @@
+{
+  "team-plugin": {
+    "employeeList": "Employee list",
+    "employeePreview": "Team preview"
+  }
+}

--- a/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/component/team-cms-element.html.twig
+++ b/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/component/team-cms-element.html.twig
@@ -1,3 +1,10 @@
 <div class="team-element">
-    <p>Employee Element Placeholder</p>
+    <sw-entity-multi-select
+        v-model="element.config.employees.value"
+        :options="employees"
+        :label="'Employees'"
+        entity="team_employee"
+        itemLabelProperty="name"
+        valueProperty="id">
+    </sw-entity-multi-select>
 </div>

--- a/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/component/team-cms-element.js
+++ b/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/component/team-cms-element.js
@@ -2,6 +2,7 @@ import template from './team-cms-element.html.twig';
 
 Shopware.Component.register('team-cms-element', {
     template,
+    inject: ['repositoryFactory'],
     mixins: [
         'cms-element'
     ],
@@ -9,6 +10,22 @@ Shopware.Component.register('team-cms-element', {
         element: {
             type: Object,
             required: true
+        }
+    },
+    data() {
+        return {
+            employees: null
+        };
+    },
+    created() {
+        this.loadEmployees();
+    },
+    methods: {
+        loadEmployees() {
+            const repository = this.repositoryFactory.create('team_employee');
+            repository.search(new Shopware.Data.Criteria(), Shopware.Context.api).then((result) => {
+                this.employees = result;
+            });
         }
     }
 });

--- a/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/index.js
+++ b/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/index.js
@@ -1,6 +1,19 @@
 import './component/team-cms-element';
 import './preview/team-cms-element-preview';
 
+Shopware.Service('cmsService').registerCmsElement({
+    name: 'team-cms-element',
+    label: 'Team',
+    component: 'team-cms-element',
+    previewComponent: 'team-cms-element-preview',
+    defaultConfig: {
+        employees: {
+            source: 'static',
+            value: []
+        }
+    }
+});
+
 Shopware.Service('cmsService').registerCmsBlock({
     name: 'team-block',
     label: 'Team Block',

--- a/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/preview/team-cms-element-preview.html.twig
+++ b/TeamPlugin/src/Resources/app/administration/src/extension/sw-cms/preview/team-cms-element-preview.html.twig
@@ -1,3 +1,3 @@
 <div class="team-element-preview">
-    <p>Employee Preview Placeholder</p>
+    <p>{{ $tc('team-plugin.employeePreview') }}</p>
 </div>

--- a/TeamPlugin/src/Resources/app/administration/src/module/team-plugin/page/team-list/index.js
+++ b/TeamPlugin/src/Resources/app/administration/src/module/team-plugin/page/team-list/index.js
@@ -1,8 +1,28 @@
 import template from './team-list.html.twig';
+const { Criteria } = Shopware.Data;
 
 Shopware.Component.register('team-list', {
     template,
+    inject: ['repositoryFactory'],
     data() {
-        return {};
+        return {
+            employees: null,
+            isLoading: false,
+            repository: null
+        };
+    },
+    created() {
+        this.repository = this.repositoryFactory.create('team_employee');
+        this.loadEmployees();
+    },
+    methods: {
+        loadEmployees() {
+            this.isLoading = true;
+            const criteria = new Criteria(1, 25);
+            this.repository.search(criteria, Shopware.Context.api).then((result) => {
+                this.employees = result;
+                this.isLoading = false;
+            });
+        }
     }
 });

--- a/TeamPlugin/src/Resources/app/administration/src/module/team-plugin/page/team-list/team-list.html.twig
+++ b/TeamPlugin/src/Resources/app/administration/src/module/team-plugin/page/team-list/team-list.html.twig
@@ -1,4 +1,14 @@
-<div class="sw-container">
-    <h1>Employee List</h1>
-    <!-- Placeholder for employee grid -->
-</div>
+<sw-page class="team-list">
+    <template #smart-bar-header>
+        <h2>{{ $tc('team-plugin.employeeList') }}</h2>
+    </template>
+    <sw-entity-listing
+        :items="employees"
+        :repository="repository"
+        :isLoading="isLoading">
+        <template #columns>
+            <sw-data-grid-column label="Name" property="name" />
+            <sw-data-grid-column label="Position" property="position" />
+        </template>
+    </sw-entity-listing>
+</sw-page>

--- a/TeamPlugin/src/Resources/config/plugin.xml
+++ b/TeamPlugin/src/Resources/config/plugin.xml
@@ -5,5 +5,6 @@
 
     <admin>
         <javascript>Resources/app/administration/src/main.js</javascript>
+        <snippets>Resources/app/administration/snippet</snippets>
     </admin>
 </plugin>

--- a/TeamPlugin/src/Resources/config/services.xml
+++ b/TeamPlugin/src/Resources/config/services.xml
@@ -4,5 +4,6 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="TeamPlugin\Core\Content\Employee\EmployeeDefinition" />
+        <service id="TeamPlugin\Migration\Migration1682235151EmployeeTable" />
     </services>
 </container>

--- a/TeamPlugin/src/TeamPlugin.php
+++ b/TeamPlugin/src/TeamPlugin.php
@@ -5,18 +5,27 @@ namespace TeamPlugin;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\Context\InstallContext;
 use Shopware\Core\Framework\Plugin\Context\UninstallContext;
+use Shopware\Core\Framework\Plugin\Context\UpdateContext;
 
 class TeamPlugin extends Plugin
 {
     public function install(InstallContext $installContext): void
     {
         parent::install($installContext);
-        // custom install logic
+        $this->updateDatabase($installContext->getContext());
+    }
+
+    public function update(UpdateContext $updateContext): void
+    {
+        parent::update($updateContext);
+        $this->updateDatabase($updateContext->getContext());
     }
 
     public function uninstall(UninstallContext $uninstallContext): void
     {
         parent::uninstall($uninstallContext);
-        // custom uninstall logic
+        if (!$uninstallContext->keepUserData()) {
+            $this->updateDatabase($uninstallContext->getContext());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add migration for team_employee table
- register CMS element and block for employee selection
- add snippets and admin module list page
- implement CMS element multi-select
- run migrations on install/update/uninstall

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685aa0f62f34832aa2ce8dfcbf462210