### PR TITLE
Add name column and getters

### DIFF
--- a/TeamPlugin/src/Core/Content/Employee/EmployeeEntity.php
+++ b/TeamPlugin/src/Core/Content/Employee/EmployeeEntity.php
@@ -11,12 +11,23 @@ class EmployeeEntity extends Entity
 {
     use EntityCustomFieldsTrait;
 
+    protected ?string $name = null;
     protected ?string $position = null;
     protected ?string $backgroundImageId = null;
     protected ?MediaEntity $backgroundImage = null;
     protected ?string $personImageId = null;
     protected ?MediaEntity $personImage = null;
     protected ?string $text = null;
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
 
     public function getPosition(): ?string
     {

--- a/TeamPlugin/src/Core/Content/Employee/EmployeeTranslationEntity.php
+++ b/TeamPlugin/src/Core/Content/Employee/EmployeeTranslationEntity.php
@@ -6,7 +6,23 @@ use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
 
 class EmployeeTranslationEntity extends TranslationEntity
 {
+    protected ?string $name = null;
     protected ?string $text = null;
+
+    public static function getTranslatedFields(): array
+    {
+        return ['name', 'position', 'text'];
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
 
     public function getText(): ?string
     {

--- a/TeamPlugin/src/Migration/Migration1682235151EmployeeTable.php
+++ b/TeamPlugin/src/Migration/Migration1682235151EmployeeTable.php
@@ -36,6 +36,7 @@ SQL;
 CREATE TABLE IF NOT EXISTS `team_employee_translation` (
     `team_employee_id` BINARY(16) NOT NULL,
     `language_id` BINARY(16) NOT NULL,
+    `name` VARCHAR(255) NULL,
     `position` VARCHAR(255) NULL,
     `text` LONGTEXT NULL,
     `created_at` DATETIME(3) NOT NULL,

--- a/TeamPlugin/src/Migration/Migration1682235152AddNameColumn.php
+++ b/TeamPlugin/src/Migration/Migration1682235152AddNameColumn.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace TeamPlugin\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1682235152AddNameColumn extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1682235152;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement(
+            'ALTER TABLE `team_employee_translation` ADD COLUMN `name` VARCHAR(255) NULL;'
+        );
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // no destructive update required
+    }
+}


### PR DESCRIPTION
## Summary
- extend translation table schema
- add migration for name column
- add name property to EmployeeEntity
- expose translation name in EmployeeTranslationEntity

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e856c8198832a86320dd7509b89e4