### PR TITLE
Use Shopware modal instead of SweetAlert

### DIFF
--- a/TeamPlugin/src/Resources/app/administration/src/module/team-employee/page/team-employee-list/index.js
+++ b/TeamPlugin/src/Resources/app/administration/src/module/team-employee/page/team-employee-list/index.js
@@ -15,6 +15,7 @@ Component.register('team-plugin-employee-list', {
             employees: [],
             repository: null,
             isLoading: false,
+            employeeToDelete: null,
         };
     },
 
@@ -56,25 +57,29 @@ Component.register('team-plugin-employee-list', {
                     this.isLoading = false;
                 });
         },
-        async onDeleteEmployee(employee) {
-            const confirmed = await this.$swal({
-                title: this.$t('team-employee.list.deleteEmployee'),
-                text: employee.position,
-                icon: 'warning',
-                showCancelButton: true,
-                confirmButtonText: this.$t('team-employee.list.deleteEmployee'),
-                cancelButtonText: this.$t('global.default.cancel')
-            });
-            if (confirmed.isConfirmed) {
-                this.isLoading = true;
-                this.repository.delete(employee.id, Shopware.Context.api)
-                    .then(() => {
-                        this.getList();
-                    })
-                    .finally(() => {
-                        this.isLoading = false;
-                    });
+        onDeleteEmployee(employee) {
+            this.employeeToDelete = employee;
+            this.$refs.confirmDeleteModal.open();
+        },
+
+        onConfirmDelete() {
+            if (!this.employeeToDelete) {
+                return;
             }
+
+            this.isLoading = true;
+            this.repository.delete(this.employeeToDelete.id, Shopware.Context.api)
+                .then(() => {
+                    this.getList();
+                })
+                .finally(() => {
+                    this.isLoading = false;
+                    this.employeeToDelete = null;
+                });
+        },
+
+        onCancelDelete() {
+            this.employeeToDelete = null;
         }
     }
 });

--- a/TeamPlugin/src/Resources/app/administration/src/module/team-employee/page/team-employee-list/team-employee-list.html.twig
+++ b/TeamPlugin/src/Resources/app/administration/src/module/team-employee/page/team-employee-list/team-employee-list.html.twig
@@ -34,4 +34,10 @@
 
         </sw-entity-listing>
     </template>
+    <sw-confirm-modal
+        ref="confirmDeleteModal"
+        :title="$t('team-employee.list.deleteEmployee')"
+        :text="employeeToDelete ? employeeToDelete.position : ''"
+        @confirm="onConfirmDelete"
+        @cancel="onCancelDelete"/>
 </sw-page>{% endraw %}


### PR DESCRIPTION
## Summary
- replace custom SweetAlert confirmation with Shopware `sw-confirm-modal`
- wire up confirm/cancel handlers

## Testing
- `node --check TeamPlugin/src/Resources/app/administration/src/module/team-employee/page/team-employee-list/index.js`


------
https://chatgpt.com/codex/tasks/task_e_685e86016268832a9282718ea35f8cb6